### PR TITLE
The method #blank? is not in Ruby core.

### DIFF
--- a/lib/matterhorn/endpoint/event.rb
+++ b/lib/matterhorn/endpoint/event.rb
@@ -65,7 +65,7 @@ class Matterhorn::Endpoint::Event < Matterhorn::Endpoint
     begin
       dc_field_arr = []
       dublin_core.each_dcterms_element do |name, content|
-        if changeable_element?(name) && !content.blank?
+        if changeable_element?(name) && (content.to_s.strip != '')
           dc_field_arr << {
             'id'    => name,
             'value' => content

--- a/lib/matterhorn/http_client.rb
+++ b/lib/matterhorn/http_client.rb
@@ -81,7 +81,7 @@ module Matterhorn
   
    
     def assemble_url(url)
-      if @multi_tenant && !@sub_domain.blank?
+      if @multi_tenant && (@sub_domain.to_s.strip != '')
         @uri.request_uri + "#{@sub_domain}/" + url
       else
         @uri.request_uri + url


### PR DESCRIPTION
And we don't include ActiveSupport as a dependency.